### PR TITLE
Update reporting file path

### DIFF
--- a/src/main/scala/coop/rchain/rbalanceweb/Constants.scala
+++ b/src/main/scala/coop/rchain/rbalanceweb/Constants.scala
@@ -8,7 +8,7 @@ object AdjustmentConstants {
 
   val adjustmentsFile  : String             = "adjustments.csv"
   val proofFile        : String             = "proof.csv"
-  val reportingDir     : String             = "/Users/lgm/work/projex/rchain/adjustedBalances/rbalance/src/main/resources" 
+  val reportingDir     : String             = "src/main/resources" 
 
   val rhocContractAddr : String             = "0x168296bb09e24a88805cb9c33356536b980d3fc5"
   val minBlockHeight   : Int                = 7598478


### PR DESCRIPTION
There was an absolute path given. Change reporting path to the same as resource path.